### PR TITLE
feat: add date parameter for periodic notes

### DIFF
--- a/docs/guide/periodic-notes.md
+++ b/docs/guide/periodic-notes.md
@@ -17,6 +17,39 @@ Period.QUARTERLY  # Quarterly note
 Period.YEARLY     # Yearly note
 ```
 
+## Accessing notes by date
+
+By default, all methods operate on the **current** periodic note. Pass `date` to access a note for a specific date:
+
+```python
+import datetime
+from aiobsidian import ContentType, Period
+
+# Get the daily note for March 15, 2024
+content = await client.periodic.get(
+    Period.DAILY, date=datetime.date(2024, 3, 15)
+)
+
+# Update a specific monthly note
+await client.periodic.update(
+    Period.MONTHLY,
+    "# June 2024 Summary",
+    date=datetime.date(2024, 6, 1),
+)
+
+# Append to a past daily note
+await client.periodic.append(
+    Period.DAILY,
+    "\n\nLate addition.",
+    date=datetime.date(2024, 3, 15),
+)
+
+# Delete a yearly note
+await client.periodic.delete(
+    Period.YEARLY, date=datetime.date(2023, 1, 1)
+)
+```
+
 ## Reading a periodic note
 
 ```python

--- a/src/aiobsidian/resources/periodic.py
+++ b/src/aiobsidian/resources/periodic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import Literal, overload
 
 from .._base_resource import ContentResource
@@ -12,11 +13,17 @@ class PeriodicNotesResource(ContentResource):
 
     _BASE_URL = "/periodic"
 
+    def _build_url(self, period: Period, date: datetime.date | None = None) -> str:
+        if date is None:
+            return f"{self._BASE_URL}/{period}/"
+        return f"{self._BASE_URL}/{period}/{date.year}/{date.month}/{date.day}/"
+
     @overload
     async def get(
         self,
         period: Period,
         *,
+        date: datetime.date | None = ...,
         content_type: Literal[ContentType.MARKDOWN] = ...,
     ) -> str: ...
 
@@ -25,6 +32,7 @@ class PeriodicNotesResource(ContentResource):
         self,
         period: Period,
         *,
+        date: datetime.date | None = ...,
         content_type: Literal[ContentType.NOTE_JSON],
     ) -> NoteJson: ...
 
@@ -33,6 +41,7 @@ class PeriodicNotesResource(ContentResource):
         self,
         period: Period,
         *,
+        date: datetime.date | None = ...,
         content_type: Literal[ContentType.DOCUMENT_MAP],
     ) -> DocumentMap: ...
 
@@ -40,21 +49,25 @@ class PeriodicNotesResource(ContentResource):
         self,
         period: Period,
         *,
+        date: datetime.date | None = None,
         content_type: ContentType = ContentType.MARKDOWN,
     ) -> str | NoteJson | DocumentMap:
         """Get the content of a periodic note.
 
         Args:
             period: The time period (e.g. `Period.DAILY`).
+            date: Specific date to retrieve. Defaults to the current period.
             content_type: Desired response format.
 
         Returns:
             Note content as `str`, `NoteJson`, or `DocumentMap`
             depending on the requested content type.
         """
-        return await self._get_content(f"{self._BASE_URL}/{period}/", content_type)
+        return await self._get_content(self._build_url(period, date), content_type)
 
-    async def update(self, period: Period, content: str) -> None:
+    async def update(
+        self, period: Period, content: str, *, date: datetime.date | None = None
+    ) -> None:
         """Replace the entire content of a periodic note.
 
         If the note does not exist, it will be created.
@@ -62,28 +75,33 @@ class PeriodicNotesResource(ContentResource):
         Args:
             period: The time period.
             content: New Markdown content for the note.
+            date: Specific date to target. Defaults to the current period.
         """
         await self._client.request(
             "PUT",
-            f"{self._BASE_URL}/{period}/",
+            self._build_url(period, date),
             content=content,
             headers={"Content-Type": ContentType.MARKDOWN},
         )
 
-    async def append(self, period: Period, content: str) -> None:
+    async def append(
+        self, period: Period, content: str, *, date: datetime.date | None = None
+    ) -> None:
         """Append content to the end of a periodic note.
 
         Args:
             period: The time period.
             content: Markdown content to append.
+            date: Specific date to target. Defaults to the current period.
         """
-        await self._append_content(f"{self._BASE_URL}/{period}/", content)
+        await self._append_content(self._build_url(period, date), content)
 
     async def patch(
         self,
         period: Period,
         content: str,
         *,
+        date: datetime.date | None = None,
         operation: PatchOperation,
         target_type: TargetType,
         target: str,
@@ -94,6 +112,7 @@ class PeriodicNotesResource(ContentResource):
         Args:
             period: The time period.
             content: Content to insert or replace.
+            date: Specific date to target. Defaults to the current period.
             operation: How to apply the content (`append`, `prepend`,
                 or `replace`).
             target_type: What to target (`heading`, `block`, or
@@ -102,7 +121,7 @@ class PeriodicNotesResource(ContentResource):
             target_delimiter: Delimiter for nested targets.
         """
         await self._patch_content(
-            f"{self._BASE_URL}/{period}/",
+            self._build_url(period, date),
             content,
             operation=operation,
             target_type=target_type,
@@ -110,10 +129,13 @@ class PeriodicNotesResource(ContentResource):
             target_delimiter=target_delimiter,
         )
 
-    async def delete(self, period: Period) -> None:
+    async def delete(
+        self, period: Period, *, date: datetime.date | None = None
+    ) -> None:
         """Delete a periodic note.
 
         Args:
             period: The time period of the note to delete.
+            date: Specific date to target. Defaults to the current period.
         """
-        await self._client.request("DELETE", f"{self._BASE_URL}/{period}/")
+        await self._client.request("DELETE", self._build_url(period, date))

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -1,3 +1,5 @@
+import datetime
+
 import httpx
 import pytest
 
@@ -137,3 +139,66 @@ async def test_patch_non_ascii_target(mock_api, client):
 
     request: httpx.Request = route.calls[0].request
     assert request.headers["target"] == "%D0%97%D0%B0%D0%B4%D0%B0%D1%87%D0%B8"
+
+
+async def test_get_markdown_with_date(mock_api, client):
+    mock_api.get("/periodic/daily/2024/3/15/").respond(200, text="# March 15")
+
+    result = await client.periodic.get(Period.DAILY, date=datetime.date(2024, 3, 15))
+
+    assert result == "# March 15"
+
+
+async def test_get_note_json_with_date(mock_api, client):
+    mock_api.get("/periodic/weekly/2024/1/8/").respond(200, json=NOTE_JSON)
+
+    result = await client.periodic.get(
+        Period.WEEKLY,
+        date=datetime.date(2024, 1, 8),
+        content_type=ContentType.NOTE_JSON,
+    )
+
+    assert isinstance(result, NoteJson)
+
+
+async def test_update_with_date(mock_api, client):
+    route = mock_api.put("/periodic/monthly/2024/6/1/").respond(204)
+
+    await client.periodic.update(
+        Period.MONTHLY, "# June", date=datetime.date(2024, 6, 1)
+    )
+
+    assert route.called
+
+
+async def test_append_with_date(mock_api, client):
+    route = mock_api.post("/periodic/daily/2024/12/25/").respond(204)
+
+    await client.periodic.append(
+        Period.DAILY, "Merry Christmas!", date=datetime.date(2024, 12, 25)
+    )
+
+    assert route.called
+
+
+async def test_patch_with_date(mock_api, client):
+    route = mock_api.patch("/periodic/daily/2024/3/15/").respond(200)
+
+    await client.periodic.patch(
+        Period.DAILY,
+        "patched",
+        date=datetime.date(2024, 3, 15),
+        operation=PatchOperation.APPEND,
+        target_type=TargetType.HEADING,
+        target="Tasks",
+    )
+
+    assert route.called
+
+
+async def test_delete_with_date(mock_api, client):
+    route = mock_api.delete("/periodic/yearly/2023/1/1/").respond(204)
+
+    await client.periodic.delete(Period.YEARLY, date=datetime.date(2023, 1, 1))
+
+    assert route.called


### PR DESCRIPTION
## Summary
- Add optional `date: datetime.date` parameter to all 5 methods of `PeriodicNotesResource`
- Support `/periodic/{period}/{year}/{month}/{day}/` API endpoint
- Full backward compatibility — omitting `date` retains existing behavior

## Test plan
- [x] 6 new tests covering date-based access for each method
- [x] All 83 tests pass
- [x] Lint and format checks pass