### PR TITLE
feat(cli): add new methods to existing resources

### DIFF
--- a/src/aiobsidian/cli/history.py
+++ b/src/aiobsidian/cli/history.py
@@ -13,6 +13,55 @@ class CLIHistoryResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def versions(self, path: str) -> list[dict[str, Any]]:
+        """List versions of a specific file in local history.
+
+        Args:
+            path: Path to the file relative to the vault root.
+
+        Returns:
+            List of version objects for the file.
+        """
+        output = await self._cli._execute("history", params={"path": path})
+        result: list[dict[str, Any]] = json.loads(output)
+        return result
+
+    async def open(self, path: str) -> None:
+        """Open the File Recovery UI for a file.
+
+        Args:
+            path: Path to the file relative to the vault root.
+        """
+        await self._cli._execute("history:open", params={"path": path})
+
+    async def diff(
+        self,
+        path: str,
+        *,
+        from_version: str | None = None,
+        to_version: str | None = None,
+        filter: str | None = None,
+    ) -> str:
+        """Get a diff between file versions.
+
+        Args:
+            path: Path to the file relative to the vault root.
+            from_version: Starting version identifier.
+            to_version: Ending version identifier.
+            filter: Filter expression for the diff output.
+
+        Returns:
+            Diff output as a string.
+        """
+        params: dict[str, str] = {"path": path}
+        if from_version is not None:
+            params["from"] = from_version
+        if to_version is not None:
+            params["to"] = to_version
+        if filter is not None:
+            params["filter"] = filter
+        return await self._cli._execute("diff", params=params)
+
     async def read(self, path: str, *, version: str | None = None) -> str:
         """Read a version from local history.
 

--- a/src/aiobsidian/cli/plugins.py
+++ b/src/aiobsidian/cli/plugins.py
@@ -13,6 +13,29 @@ class CLIPluginsResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def info(self, plugin_id: str) -> dict[str, Any]:
+        """Get details about a plugin.
+
+        Args:
+            plugin_id: Plugin identifier.
+
+        Returns:
+            Plugin details.
+        """
+        output = await self._cli._execute("plugin", params={"id": plugin_id})
+        result: dict[str, Any] = json.loads(output)
+        return result
+
+    async def restrict(self, *, on: bool) -> None:
+        """Toggle restricted mode for plugins.
+
+        Args:
+            on: If ``True``, enable restricted mode;
+                if ``False``, disable it.
+        """
+        flags = ["--on"] if on else ["--off"]
+        await self._cli._execute("plugins:restrict", flags=flags)
+
     async def enabled(self) -> list[dict[str, Any]]:
         """List enabled plugins.
 

--- a/src/aiobsidian/cli/publish.py
+++ b/src/aiobsidian/cli/publish.py
@@ -13,6 +13,16 @@ class CLIPublishResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def open(self, path: str | None = None) -> None:
+        """Open a file on the published site.
+
+        Args:
+            path: Path to the file to open. If ``None``, opens the
+                site root.
+        """
+        params = {"path": path} if path is not None else None
+        await self._cli._execute("publish:open", params=params)
+
     async def site(self) -> dict[str, Any]:
         """Get Publish site information.
 

--- a/src/aiobsidian/cli/random_note.py
+++ b/src/aiobsidian/cli/random_note.py
@@ -10,6 +10,10 @@ class CLIRandomResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def open(self) -> None:
+        """Open a random note in the Obsidian UI."""
+        await self._cli._execute("random")
+
     async def read(self) -> str:
         """Read the content of a random note.
 

--- a/src/aiobsidian/cli/search.py
+++ b/src/aiobsidian/cli/search.py
@@ -13,6 +13,14 @@ class CLISearchResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def open(self, query: str) -> None:
+        """Open the search panel in the Obsidian UI with a query.
+
+        Args:
+            query: Search query string.
+        """
+        await self._cli._execute("search:open", params={"query": query})
+
     async def query(
         self,
         query: str,

--- a/src/aiobsidian/cli/sync.py
+++ b/src/aiobsidian/cli/sync.py
@@ -13,6 +13,18 @@ class CLISyncResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def toggle(self, *, on: bool) -> None:
+        """Pause or resume Obsidian Sync.
+
+        Args:
+            on: If ``True``, resume sync; if ``False``, pause sync.
+        """
+        await self._cli._execute("sync:on" if on else "sync:off")
+
+    async def open(self) -> None:
+        """Open the Sync history UI."""
+        await self._cli._execute("sync:open")
+
     async def status(self) -> dict[str, Any]:
         """Get sync status information.
 

--- a/src/aiobsidian/cli/tasks.py
+++ b/src/aiobsidian/cli/tasks.py
@@ -40,6 +40,17 @@ class CLITasksResource(BaseCLIResource):
         result: list[dict[str, Any]] = json.loads(output)
         return result
 
+    async def toggle(self, path: str, line: int) -> None:
+        """Toggle a task's completion status.
+
+        Args:
+            path: Path to the file containing the task.
+            line: Line number of the task in the file.
+        """
+        await self._cli._execute(
+            "task", params={"path": path, "line": str(line)}, flags=["--toggle"]
+        )
+
     async def create(self, content: str, *, tags: str | None = None) -> None:
         """Create a new task.
 

--- a/src/aiobsidian/cli/templates.py
+++ b/src/aiobsidian/cli/templates.py
@@ -36,6 +36,14 @@ class CLITemplatesResource(BaseCLIResource):
         flags = ["--resolve"] if resolve else None
         return await self._cli._execute("template:read", params=params, flags=flags)
 
+    async def insert(self, name: str) -> None:
+        """Insert a template into the active file.
+
+        Args:
+            name: Template name to insert.
+        """
+        await self._cli._execute("template:insert", params={"name": name})
+
     async def list(self) -> list[dict[str, Any]]:
         """List available templates.
 

--- a/src/aiobsidian/cli/vault.py
+++ b/src/aiobsidian/cli/vault.py
@@ -13,6 +13,14 @@ class CLIVaultResource(BaseCLIResource):
         _cli: Reference to the parent ``ObsidianCLI`` instance.
     """
 
+    async def open(self, path: str) -> None:
+        """Open a file in the Obsidian UI.
+
+        Args:
+            path: Path to the file relative to the vault root.
+        """
+        await self._cli._execute("open", params={"path": path})
+
     async def read(self, path: str) -> str:
         """Read the content of a vault file.
 

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -8,6 +8,49 @@ HISTORY_FILES = [
 ]
 
 
+async def test_versions(cli):
+    versions = [
+        {"version": "v1", "date": "2026-03-16T09:00:00Z"},
+        {"version": "v2", "date": "2026-03-16T10:00:00Z"},
+    ]
+    cli._execute.return_value = json.dumps(versions)
+    result = await cli.history.versions("notes/todo.md")
+    assert result == versions
+    cli._execute.assert_awaited_once_with("history", params={"path": "notes/todo.md"})
+
+
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.history.open("notes/todo.md")
+    cli._execute.assert_awaited_once_with(
+        "history:open", params={"path": "notes/todo.md"}
+    )
+
+
+async def test_diff(cli):
+    cli._execute.return_value = "- old line\n+ new line"
+    result = await cli.history.diff("notes/todo.md")
+    assert result == "- old line\n+ new line"
+    cli._execute.assert_awaited_once_with("diff", params={"path": "notes/todo.md"})
+
+
+async def test_diff_all_params(cli):
+    cli._execute.return_value = "- old\n+ new"
+    result = await cli.history.diff(
+        "notes/todo.md", from_version="v1", to_version="v2", filter="added"
+    )
+    assert result == "- old\n+ new"
+    cli._execute.assert_awaited_once_with(
+        "diff",
+        params={
+            "path": "notes/todo.md",
+            "from": "v1",
+            "to": "v2",
+            "filter": "added",
+        },
+    )
+
+
 async def test_list(cli):
     cli._execute.return_value = json.dumps(HISTORY_FILES)
     result = await cli.history.list()

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -12,6 +12,26 @@ ENABLED_PLUGINS = [
 ]
 
 
+async def test_info(cli):
+    plugin_info = {"id": "dataview", "name": "Dataview", "version": "0.5.66"}
+    cli._execute.return_value = json.dumps(plugin_info)
+    result = await cli.plugins.info("dataview")
+    assert result == plugin_info
+    cli._execute.assert_awaited_once_with("plugin", params={"id": "dataview"})
+
+
+async def test_restrict_on(cli):
+    cli._execute.return_value = ""
+    await cli.plugins.restrict(on=True)
+    cli._execute.assert_awaited_once_with("plugins:restrict", flags=["--on"])
+
+
+async def test_restrict_off(cli):
+    cli._execute.return_value = ""
+    await cli.plugins.restrict(on=False)
+    cli._execute.assert_awaited_once_with("plugins:restrict", flags=["--off"])
+
+
 async def test_list(cli):
     cli._execute.return_value = json.dumps(PLUGINS)
     result = await cli.plugins.list()

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -12,6 +12,20 @@ PUBLISHED_FILES = [
 PUBLISH_STATUS = {"path": "index.md", "published": True, "changed": False}
 
 
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.publish.open("notes/index.md")
+    cli._execute.assert_awaited_once_with(
+        "publish:open", params={"path": "notes/index.md"}
+    )
+
+
+async def test_open_no_path(cli):
+    cli._execute.return_value = ""
+    await cli.publish.open()
+    cli._execute.assert_awaited_once_with("publish:open", params=None)
+
+
 async def test_site(cli):
     cli._execute.return_value = json.dumps(SITE_INFO)
     result = await cli.publish.site()

--- a/tests/test_cli_random_note.py
+++ b/tests/test_cli_random_note.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.random.open()
+    cli._execute.assert_awaited_once_with("random")
+
+
 async def test_read(cli):
     cli._execute.return_value = "# Random Note\n\nSome content here."
     result = await cli.random.read()

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import json
 
 
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.search.open("test query")
+    cli._execute.assert_awaited_once_with("search:open", params={"query": "test query"})
+
+
 async def test_query(cli):
     results = [{"file": "note.md", "score": 1.0}]
     cli._execute.return_value = json.dumps(results)

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -14,6 +14,24 @@ DELETED_FILES = [
 ]
 
 
+async def test_toggle_on(cli):
+    cli._execute.return_value = ""
+    await cli.sync.toggle(on=True)
+    cli._execute.assert_awaited_once_with("sync:on")
+
+
+async def test_toggle_off(cli):
+    cli._execute.return_value = ""
+    await cli.sync.toggle(on=False)
+    cli._execute.assert_awaited_once_with("sync:off")
+
+
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.sync.open()
+    cli._execute.assert_awaited_once_with("sync:open")
+
+
 async def test_status(cli):
     cli._execute.return_value = json.dumps(SYNC_STATUS)
     result = await cli.sync.status()

--- a/tests/test_cli_tasks.py
+++ b/tests/test_cli_tasks.py
@@ -45,6 +45,14 @@ async def test_list_all_flags(cli):
     )
 
 
+async def test_toggle(cli):
+    cli._execute.return_value = ""
+    await cli.tasks.toggle("todo.md", 5)
+    cli._execute.assert_awaited_once_with(
+        "task", params={"path": "todo.md", "line": "5"}, flags=["--toggle"]
+    )
+
+
 async def test_create(cli):
     cli._execute.return_value = ""
     await cli.tasks.create("Buy milk")

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -8,6 +8,14 @@ TEMPLATES_LIST = [
 ]
 
 
+async def test_insert(cli):
+    cli._execute.return_value = ""
+    await cli.templates.insert("Daily Note")
+    cli._execute.assert_awaited_once_with(
+        "template:insert", params={"name": "Daily Note"}
+    )
+
+
 async def test_list(cli):
     cli._execute.return_value = json.dumps(TEMPLATES_LIST)
     result = await cli.templates.list()

--- a/tests/test_cli_vault.py
+++ b/tests/test_cli_vault.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import json
 
 
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.vault.open("note.md")
+    cli._execute.assert_awaited_once_with("open", params={"path": "note.md"})
+
+
 async def test_read(cli):
     cli._execute.return_value = "# Hello"
     result = await cli.vault.read("note.md")


### PR DESCRIPTION
## Summary
- Adds 15 new methods to 9 existing CLI resources to cover previously missing Obsidian CLI commands
- vault.open, search.open, tasks.toggle, templates.insert, plugins.info/restrict, history.versions/open/diff, sync.toggle/open, publish.open, random_note.open
- 17 new tests (249 → 266 total)

Closes #18

## Test plan
- [x] All 266 tests pass (`uv run python -m pytest`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [x] Format clean (`uv run ruff format --check src/ tests/`)