### PR TITLE
feat(cli): add system resource

### DIFF
--- a/src/aiobsidian/_cli.py
+++ b/src/aiobsidian/_cli.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from .cli.search import CLISearchResource
     from .cli.snippets import CLISnippetsResource
     from .cli.sync import CLISyncResource
+    from .cli.system import CLISystemResource
     from .cli.tags import CLITagsResource
     from .cli.tasks import CLITasksResource
     from .cli.templates import CLITemplatesResource
@@ -306,6 +307,13 @@ class ObsidianCLI:
         from .cli.aliases import CLIAliasesResource
 
         return CLIAliasesResource(self)
+
+    @cached_property
+    def system(self) -> CLISystemResource:
+        """Access system commands (version, help, reload, restart, vaults)."""
+        from .cli.system import CLISystemResource
+
+        return CLISystemResource(self)
 
     @cached_property
     def bases(self) -> CLIBasesResource:

--- a/src/aiobsidian/cli/system.py
+++ b/src/aiobsidian/cli/system.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ._base import BaseCLIResource
+
+
+class CLISystemResource(BaseCLIResource):
+    """CLI resource for general system commands.
+
+    Attributes:
+        _cli: Reference to the parent ``ObsidianCLI`` instance.
+    """
+
+    async def version(self) -> str:
+        """Get the Obsidian version.
+
+        Returns:
+            Obsidian version string.
+        """
+        return await self._cli._execute("version")
+
+    async def help(self) -> list[dict[str, Any]]:
+        """List all available CLI commands.
+
+        Returns:
+            List of command descriptions.
+        """
+        output = await self._cli._execute("help")
+        result: list[dict[str, Any]] = json.loads(output)
+        return result
+
+    async def reload(self) -> None:
+        """Reload the Obsidian window."""
+        await self._cli._execute("reload")
+
+    async def restart(self) -> None:
+        """Restart the Obsidian application."""
+        await self._cli._execute("restart")
+
+    async def vaults(self) -> list[dict[str, Any]]:
+        """List all known vaults (desktop only).
+
+        Returns:
+            List of vault objects.
+        """
+        output = await self._cli._execute("vaults")
+        result: list[dict[str, Any]] = json.loads(output)
+        return result

--- a/tests/test_cli_system.py
+++ b/tests/test_cli_system.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+COMMANDS = [
+    {"name": "read", "description": "Read a file"},
+    {"name": "create", "description": "Create a file"},
+]
+
+VAULTS = [
+    {"name": "MyVault", "path": "/vaults/MyVault"},
+    {"name": "Work", "path": "/vaults/Work"},
+]
+
+
+async def test_version(cli):
+    cli._execute.return_value = "1.8.0"
+    result = await cli.system.version()
+    assert result == "1.8.0"
+    cli._execute.assert_awaited_once_with("version")
+
+
+async def test_help(cli):
+    cli._execute.return_value = json.dumps(COMMANDS)
+    result = await cli.system.help()
+    assert result == COMMANDS
+    cli._execute.assert_awaited_once_with("help")
+
+
+async def test_reload(cli):
+    cli._execute.return_value = ""
+    await cli.system.reload()
+    cli._execute.assert_awaited_once_with("reload")
+
+
+async def test_restart(cli):
+    cli._execute.return_value = ""
+    await cli.system.restart()
+    cli._execute.assert_awaited_once_with("restart")
+
+
+async def test_vaults(cli):
+    cli._execute.return_value = json.dumps(VAULTS)
+    result = await cli.system.vaults()
+    assert result == VAULTS
+    cli._execute.assert_awaited_once_with("vaults")


### PR DESCRIPTION
## Summary
- New `CLISystemResource` with 5 methods: `version()`, `help()`, `reload()`, `restart()`, `vaults()`
- Added `@cached_property` and `TYPE_CHECKING` import in `_cli.py`
- 5 new tests (266 → 271 total)

Closes #19

## Test plan
- [x] All 271 tests pass (`uv run python -m pytest`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [x] Format clean (`uv run ruff format --check src/ tests/`)