### PR TITLE
feat(cli): add web resource

### DIFF
--- a/src/aiobsidian/_cli.py
+++ b/src/aiobsidian/_cli.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from .cli.templates import CLITemplatesResource
     from .cli.themes import CLIThemesResource
     from .cli.vault import CLIVaultResource
+    from .cli.web import CLIWebResource
     from .cli.workspaces import CLIWorkspacesResource
 
 logger = logging.getLogger(__name__)
@@ -329,6 +330,13 @@ class ObsidianCLI:
         from .cli.bases import CLIBasesResource
 
         return CLIBasesResource(self)
+
+    @cached_property
+    def web(self) -> CLIWebResource:
+        """Access web viewer operations (open)."""
+        from .cli.web import CLIWebResource
+
+        return CLIWebResource(self)
 
     # -- lifecycle ---------------------------------------------------------
 

--- a/src/aiobsidian/cli/web.py
+++ b/src/aiobsidian/cli/web.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from ._base import BaseCLIResource
+
+
+class CLIWebResource(BaseCLIResource):
+    """CLI resource for the web viewer.
+
+    Attributes:
+        _cli: Reference to the parent ``ObsidianCLI`` instance.
+    """
+
+    async def open(self, url: str) -> None:
+        """Open a URL in the Obsidian web viewer.
+
+        Args:
+            url: The URL to open.
+        """
+        await self._cli._execute("web", params={"url": url})

--- a/tests/test_cli_web.py
+++ b/tests/test_cli_web.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+async def test_open(cli):
+    cli._execute.return_value = ""
+    await cli.web.open("https://example.com")
+    cli._execute.assert_awaited_once_with("web", params={"url": "https://example.com"})


### PR DESCRIPTION
## Summary
- New `CLIWebResource` with `open(url)` method for the Obsidian web viewer
- Added `@cached_property` and `TYPE_CHECKING` import in `_cli.py`
- Added test coverage

Closes #21