### PR TITLE
docs: update documentation for full CLI coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.0] — 2026-03-29
+
+### Added
+- CLI-first architecture with `ObsidianCLI` async subprocess wrapper
+- 26 CLI resources: vault, daily, search, properties, tags, links, tasks, commands, templates, bookmarks, plugins, themes, snippets, sync, publish, history, workspaces, hotkeys, outline, random, aliases, bases, system, tabs, web, dev
+- Full Obsidian CLI v1.12+ coverage with all flags and parameters
+- Migrated to `uv audit` for dependency vulnerability scanning
+
+### Changed
+- Primary interface is now `ObsidianCLI` (CLI-based); REST via `ObsidianClient` is optional
+
+## [0.2.0] — 2026-03-15
+
+### Added
+- Optional date parameter for accessing periodic notes by date
+
 ## [0.1.1] — 2026-02-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,7 +77,26 @@ asyncio.run(main())
 | **properties** | `cli.properties` | YAML frontmatter properties |
 | **tags** | `cli.tags` | Tag listing, lookup, rename |
 | **links** | `cli.links` | Outgoing links, backlinks, unresolved, orphans |
-| **tasks** | `cli.tasks` | Task listing, creation, completion |
+| **tasks** | `cli.tasks` | Task listing, creation, completion, toggle |
+| **commands** | `cli.commands` | List and execute Obsidian commands |
+| **templates** | `cli.templates` | List, read, insert templates |
+| **bookmarks** | `cli.bookmarks` | List and add bookmarks |
+| **plugins** | `cli.plugins` | Plugin management |
+| **themes** | `cli.themes` | Theme management |
+| **snippets** | `cli.snippets` | CSS snippet management |
+| **sync** | `cli.sync` | Obsidian Sync operations |
+| **publish** | `cli.publish` | Obsidian Publish operations |
+| **history** | `cli.history` | Local file history |
+| **workspaces** | `cli.workspaces` | Workspace management |
+| **hotkeys** | `cli.hotkeys` | Hotkey operations |
+| **outline** | `cli.outline` | Document outline (headings) |
+| **random** | `cli.random` | Random note |
+| **aliases** | `cli.aliases` | Note aliases |
+| **bases** | `cli.bases` | Obsidian Bases / databases |
+| **system** | `cli.system` | Version, reload, restart, vaults |
+| **tabs** | `cli.tabs` | Tab management, recents |
+| **web** | `cli.web` | Open URLs in web viewer |
+| **dev** | `cli.dev` | Developer/debugging tools |
 
 ### REST resources
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -30,7 +30,26 @@ asyncio.run(main())
 | **properties** | `cli.properties` | YAML frontmatter properties: list, read, set, remove |
 | **tags** | `cli.tags` | Tags: list, get notes by tag, rename |
 | **links** | `cli.links` | Outgoing links, backlinks, unresolved, orphans |
-| **tasks** | `cli.tasks` | Tasks: list, create, complete |
+| **tasks** | `cli.tasks` | Tasks: list, create, complete, toggle |
+| **commands** | `cli.commands` | List and execute Obsidian commands |
+| **templates** | `cli.templates` | List, read, insert templates |
+| **bookmarks** | `cli.bookmarks` | List and add bookmarks |
+| **plugins** | `cli.plugins` | Plugin management |
+| **themes** | `cli.themes` | Theme management |
+| **snippets** | `cli.snippets` | CSS snippet management |
+| **sync** | `cli.sync` | Obsidian Sync operations |
+| **publish** | `cli.publish` | Obsidian Publish operations |
+| **history** | `cli.history` | Local file history |
+| **workspaces** | `cli.workspaces` | Workspace management |
+| **hotkeys** | `cli.hotkeys` | Hotkey operations |
+| **outline** | `cli.outline` | Document outline (headings) |
+| **random** | `cli.random` | Random note |
+| **aliases** | `cli.aliases` | Note aliases |
+| **bases** | `cli.bases` | Obsidian Bases / databases |
+| **system** | `cli.system` | Version, reload, restart, vaults |
+| **tabs** | `cli.tabs` | Tab management, recents |
+| **web** | `cli.web` | Open URLs in web viewer |
+| **dev** | `cli.dev` | Developer/debugging tools |
 
 ### Reading and writing notes
 

--- a/docs/reference/resources/cli-dev.md
+++ b/docs/reference/resources/cli-dev.md
@@ -1,0 +1,3 @@
+# CLI Dev Resource
+
+::: aiobsidian.cli.dev.CLIDevResource

--- a/docs/reference/resources/cli-system.md
+++ b/docs/reference/resources/cli-system.md
@@ -1,0 +1,3 @@
+# CLI System Resource
+
+::: aiobsidian.cli.system.CLISystemResource

--- a/docs/reference/resources/cli-tabs.md
+++ b/docs/reference/resources/cli-tabs.md
@@ -1,0 +1,3 @@
+# CLI Tabs Resource
+
+::: aiobsidian.cli.tabs.CLITabsResource

--- a/docs/reference/resources/cli-web.md
+++ b/docs/reference/resources/cli-web.md
@@ -1,0 +1,3 @@
+# CLI Web Resource
+
+::: aiobsidian.cli.web.CLIWebResource

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,10 @@ nav:
           - Random: reference/resources/cli-random.md
           - Aliases: reference/resources/cli-aliases.md
           - Bases: reference/resources/cli-bases.md
+          - System: reference/resources/cli-system.md
+          - Tabs: reference/resources/cli-tabs.md
+          - Web: reference/resources/cli-web.md
+          - Dev: reference/resources/cli-dev.md
       - ObsidianClient (REST): reference/client.md
       - REST Resources:
           - Vault: reference/resources/vault.md

--- a/src/aiobsidian/_cli.py
+++ b/src/aiobsidian/_cli.py
@@ -46,7 +46,8 @@ class ObsidianCLI:
     Provides access to vault operations, daily notes, search, properties,
     tags, links, tasks, commands, templates, bookmarks, plugins, themes,
     snippets, sync, publish, history, workspaces, hotkeys, outline,
-    random notes, aliases, and bases through resource properties.
+    random notes, aliases, bases, system, tabs, web, and dev
+    through resource properties.
 
     Can be used as an async context manager:
 


### PR DESCRIPTION
## Summary
- Expanded CLI resources table in README.md and quickstart.md (7 → 26 resources)
- Added mkdocs API reference pages for system, tabs, web, dev resources
- Updated mkdocs.yml navigation with 4 new pages
- Added CHANGELOG entries for 0.2.0 and 0.3.0
- Updated ObsidianCLI class docstring to include all resources