### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.3.0] — 2026-03-29
+## [0.4.0] — 2026-03-29
+
+### Added
+- 4 new CLI resources: system, tabs, web, dev
+- Full Obsidian CLI v1.12+ coverage with all flags and parameters across all resources
+- New methods in existing resources: vault.open, search.open, tasks.toggle, templates.insert, plugins.info, plugins.restrict, history.versions, history.open, history.diff, sync.toggle, sync.open, publish.open, random.open
+
+## [0.3.0] — 2026-03-22
 
 ### Added
 - CLI-first architecture with `ObsidianCLI` async subprocess wrapper
-- 26 CLI resources: vault, daily, search, properties, tags, links, tasks, commands, templates, bookmarks, plugins, themes, snippets, sync, publish, history, workspaces, hotkeys, outline, random, aliases, bases, system, tabs, web, dev
-- Full Obsidian CLI v1.12+ coverage with all flags and parameters
+- 22 CLI resources: vault, daily, search, properties, tags, links, tasks, commands, templates, bookmarks, plugins, themes, snippets, sync, publish, history, workspaces, hotkeys, outline, random, aliases, bases
 - Migrated to `uv audit` for dependency vulnerability scanning
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aiobsidian"
-version = "0.3.0"
+version = "0.4.0"
 description = "Async Python client for Obsidian CLI and Local REST API"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "aiobsidian"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Bump version 0.3.0 → 0.4.0
- Fix CHANGELOG: separate 0.3.0 (CLI architecture) from 0.4.0 (full CLI coverage)