### PR TITLE
chore: unify project description across all sources

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: aiobsidian
 site_url: https://kudato.github.io/aiobsidian
-site_description: Async Python client for Obsidian — CLI-first with optional REST support
+site_description: Async Python client for Obsidian CLI and Local REST API plugin
 repo_url: https://github.com/kudato/aiobsidian
 repo_name: kudato/aiobsidian
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "aiobsidian"
 version = "0.4.0"
-description = "Async Python client for Obsidian CLI and Local REST API"
+description = "Async Python client for Obsidian CLI and Local REST API plugin"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/aiobsidian/__init__.py
+++ b/src/aiobsidian/__init__.py
@@ -1,4 +1,4 @@
-"""Async Python client for Obsidian Local REST API and CLI."""
+"""Async Python client for Obsidian CLI and Local REST API plugin."""
 
 from ._cli import ObsidianCLI
 from ._client import ObsidianClient


### PR DESCRIPTION
## Summary
- Unified project description to "Async Python client for Obsidian CLI and Local REST API plugin" in pyproject.toml, `__init__.py`, and mkdocs.yml
- Added "plugin" to clarify REST API is provided by a plugin
- Ensured CLI is mentioned first (CLI-first architecture)