### PR TITLE
fix(cli): fix None check in publish.status and builtin shadowing in dev.dom

### DIFF
--- a/src/aiobsidian/cli/dev.py
+++ b/src/aiobsidian/cli/dev.py
@@ -69,7 +69,7 @@ class CLIDevResource(BaseCLIResource):
         self,
         selector: str,
         *,
-        all: bool = False,
+        match_all: bool = False,
         text: bool = False,
         attr: str | None = None,
         css: str | None = None,
@@ -78,7 +78,7 @@ class CLIDevResource(BaseCLIResource):
 
         Args:
             selector: CSS selector for the element(s).
-            all: If ``True``, match all elements instead of just the first.
+            match_all: If ``True``, match all elements instead of just the first.
             text: If ``True``, return text content only.
             attr: Return this attribute value from matched elements.
             css: Return this CSS property value from matched elements.
@@ -92,7 +92,7 @@ class CLIDevResource(BaseCLIResource):
         if css is not None:
             params["css"] = css
         flags: list[str] = []
-        if all:
+        if match_all:
             flags.append("--all")
         if text:
             flags.append("--text")

--- a/src/aiobsidian/cli/publish.py
+++ b/src/aiobsidian/cli/publish.py
@@ -42,7 +42,7 @@ class CLIPublishResource(BaseCLIResource):
         Returns:
             Publication status details.
         """
-        params = {"path": path} if path else None
+        params = {"path": path} if path is not None else None
         output = await self._cli._execute("publish:status", params=params)
         result: dict[str, Any] = json.loads(output)
         return result

--- a/tests/test_cli_dev.py
+++ b/tests/test_cli_dev.py
@@ -66,7 +66,9 @@ async def test_dom(cli):
 
 async def test_dom_all_flags(cli):
     cli._execute.return_value = "text content"
-    result = await cli.dev.dom("#app", all=True, text=True, attr="data-id", css="color")
+    result = await cli.dev.dom(
+        "#app", match_all=True, text=True, attr="data-id", css="color"
+    )
     assert result == "text content"
     cli._execute.assert_awaited_once_with(
         "dev:dom",


### PR DESCRIPTION
## Summary
- **publish.py**: `if path` → `if path is not None` in `status()` — fixes bug where `path=""` was silently treated as `None`, inconsistent with adjacent `open()` and `add()` methods
- **dev.py**: rename `all` → `match_all` parameter in `dom()` — avoids shadowing Python's built-in `all()`

## Test plan
- [x] `test_cli_publish.py` — 9/9 passed
- [x] `test_cli_dev.py` — 15/15 passed
- [x] ruff clean