### PR TITLE
docs: fix documentation errors and improve CLI setup guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-`aiobsidian` — async Python client for Obsidian. CLI-first: works out of the box with the [Obsidian CLI](https://github.com/nicholasgasior/obsidian) (v1.12+). Optional REST support via the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin (`pip install aiobsidian[rest]`).
+`aiobsidian` — async Python client for Obsidian. CLI-first: works out of the box with the [Obsidian CLI](https://obsidian.md/cli) (v1.12+). Optional REST support via the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) plugin (`pip install aiobsidian[rest]`).
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import asyncio
 from aiobsidian import ObsidianClient
 
 async def main():
-    async with ObsidianClient("your-api-key") as client:
+    async with ObsidianClient(api_key="your-api-key") as client:
         status = await client.system.status()
         print(status.versions.obsidian)
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -33,8 +33,6 @@ cli = ObsidianCLI("MyVault", binary="/opt/obsidian/bin/obsidian")
 cli = ObsidianCLI("MyVault", timeout=60.0)
 ```
 
-Per-command timeout override is also available via the `_execute` method internally.
-
 ---
 
 ## ObsidianClient (REST)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,11 +12,10 @@ aiobsidian supports two interfaces for interacting with Obsidian:
 ## CLI setup
 
 1. **Obsidian** — download from [obsidian.md](https://obsidian.md)
-2. **Obsidian CLI** — included with Obsidian v1.12+. Verify installation:
+2. **Enable the CLI** (v1.12+) — open Obsidian → Settings → General → enable "Command line interface"
 
-    ```bash
-    obsidian version
-    ```
+    !!! note
+        On macOS, creating the CLI symlink at `/usr/local/bin/obsidian` requires administrator privileges. On Linux, the binary is placed at `~/.local/bin/obsidian` — ensure this directory is in your `PATH`.
 
 3. **Install aiobsidian**:
 

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -29,7 +29,7 @@ try:
     async with ObsidianCLI("MyVault") as cli:
         content = await cli.vault.read("note.md")
 except BinaryNotFoundError:
-    print("Obsidian CLI binary not found. Install Obsidian v1.12+ or pass binary= explicitly.")
+    print("Obsidian CLI binary not found. Install Obsidian v1.12+ and enable the CLI, or pass binary= explicitly.")
 except CommandError as e:
     print(f"Command {e.command!r} failed (exit code {e.exit_code}): {e.stderr}")
 except CLITimeoutError as e:

--- a/docs/guide/search.md
+++ b/docs/guide/search.md
@@ -55,11 +55,11 @@ Each search method returns a list of `SearchResult` objects:
 | `filename` | `str` | Path to the matching file |
 | `score` | `float \| None` | Relevance score (simple search only) |
 | `matches` | `list[SearchMatch] \| None` | Match locations with context (simple search only) |
-| `result` | `Any` | Raw result data (Dataview/JsonLogic only) |
+| `result` | `dict[str, Any] \| list[Any] \| None` | Raw result data (Dataview/JsonLogic only) |
 
 Each `SearchMatch` contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `match` | `dict[str, int]` | Match start/end positions |
+| `match` | `MatchSpan` | Match start/end positions |
 | `context` | `str` | Surrounding text context |

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -12,6 +12,8 @@
 
 ## Search Models
 
+::: aiobsidian.models.search.MatchSpan
+
 ::: aiobsidian.models.search.SearchMatch
 
 ::: aiobsidian.models.search.SearchResult


### PR DESCRIPTION
## Summary

- Fix fabricated CLI link in CLAUDE.md (`github.com/nicholasgasior/obsidian` → `obsidian.md/cli`)
- Fix incorrect types in search guide (`Any` → `dict[str, Any] | list[Any] | None`, `dict[str, int]` → `MatchSpan`)
- Add missing `MatchSpan` model to reference docs
- Rewrite CLI setup instructions: add enablement step, macOS/Linux platform notes
- Remove private `_execute` reference from configuration docs
- Use keyword arg for `ObsidianClient` in README for consistency
- Improve `BinaryNotFoundError` guidance in error handling example

## Test plan

- [x] `mkdocs build --strict` passes
- [x] All v1.12+ references verified against Obsidian changelog (CLI introduced in 1.12.0)
- [x] All type annotations cross-referenced with source models
- [x] No regressions in existing documentation