### PR TITLE
fix(rest): catch AttributeError when JSON body is not a mapping

### DIFF
--- a/src/aiobsidian/_client.py
+++ b/src/aiobsidian/_client.py
@@ -142,7 +142,7 @@ class ObsidianClient:
             data = response.json()
             message = data.get("message", message)
             error_code = data.get("errorCode")
-        except (ValueError, KeyError):
+        except (ValueError, AttributeError):
             pass
 
         status = response.status_code

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,6 +89,14 @@ async def test_raise_for_status_json_without_message_key(mock_api, client):
     assert "detail" in exc_info.value.message
 
 
+async def test_raise_for_status_json_array_body(mock_api, client):
+    """A JSON array body must not leak AttributeError; APIError is raised instead."""
+    mock_api.get("/x").respond(500, json=[{"error": "boom"}])
+    with pytest.raises(APIError) as exc_info:
+        await client.request("GET", "/x")
+    assert exc_info.value.status_code == 500
+
+
 async def test_api_error_str_with_error_code():
     err = APIError(404, "Not found", 40401)
     assert str(err) == "[404] Not found (error_code=40401)"


### PR DESCRIPTION
Fixes #40.

`dict.get()` never raises `KeyError`, so the existing `except (ValueError, KeyError)` in `_raise_for_status` was dead. When the server returns a JSON array (or any non-mapping JSON value), `data.get("message", message)` raises `AttributeError`, which leaks out instead of producing the intended `APIError`.

Swapped `KeyError` for `AttributeError` and added a regression test that mocks a 500 response with a JSON array body and asserts `APIError` is raised.